### PR TITLE
add configuration value 'WindowHeight'

### DIFF
--- a/lib/cli-status.coffee
+++ b/lib/cli-status.coffee
@@ -18,3 +18,6 @@ module.exports =
 
   # serialize: ->
   #   cliStatusViewState: @cliStatusView.serialize()
+
+  configDefaults:
+    'WindowHeight': 300

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -30,6 +30,8 @@ class CommandOutputView extends View
         @subview 'cmdEditor', new EditorView(mini: true, placeholderText: 'input your command here')
 
   initialize: ->
+    @subscribe atom.config.observe 'terminal-status.WindowHeight', => @adjustWindowHeight()
+
     @userHome = process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE;
     cmd = 'test -e /etc/profile && source /etc/profile;test -e ~/.profile && source ~/.profile; node -pe "JSON.stringify(process.env)"'
     exec cmd, (code, stdout, stderr) ->
@@ -54,6 +56,10 @@ class CommandOutputView extends View
         return @ls args
       @spawn inputCmd, cmd, args
 
+
+  adjustWindowHeight: ->
+    maxHeight = atom.config.get('terminal-status.WindowHeight')
+    @cliOutput.css("max-height", "#{maxHeight}px")
 
   showCmd: ->
     @cmdEditor.show()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terminal-status",
   "main": "./lib/cli-status",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A terminal interface and status icon",
   "repository": "https://github.com/guileen/terminal-status",
   "license": "MIT",

--- a/spec/cli-status-spec.coffee
+++ b/spec/cli-status-spec.coffee
@@ -27,3 +27,12 @@ describe "CliStatus", ->
         expect(atom.workspaceView.find('.cli-status')).toExist()
         atom.workspaceView.trigger 'cli-status:toggle'
         expect(atom.workspaceView.find('.cli-status')).not.toExist()
+
+  describe "when cli-status is activated", ->
+    it "should have configuration set up with defaults"
+
+    waitsForPromise ->
+      activationPromise
+
+    runs ->
+        expect(atom.config.get('terminal-status.WindowHeight')).toBe(300)

--- a/stylesheets/cli-status.less
+++ b/stylesheets/cli-status.less
@@ -21,6 +21,7 @@
     }
   }
   .terminal {
+    // let's keep this as a fallback
     max-height: 300px;
     overflow-y: scroll;
     bottom: @component-padding;


### PR DESCRIPTION
A 300px window on the bottom annoyed me a bit, so I added a configuration value to the package, now I can make it a bit smaller using the atom.io package preferences. The window size should update immediately (used config.observe). I hope the code is fine, I haven't really worked with atom.io packages before.
