### PR TITLE
PR: Enable copying from terminal, destroy terminal keybinding, linux/win32 keybindings and more

### DIFF
--- a/keymaps/cli-status.cson
+++ b/keymaps/cli-status.cson
@@ -12,9 +12,11 @@
   'cmd-shift-t': 'terminal-status:new'
   'cmd-shift-j': 'terminal-status:next'
   'cmd-shift-k': 'terminal-status:prev'
+  'cmd-shift-x': 'terminal-status:destroy'
 
 '.platform-linux .workspace, .platform-win32 .workspace':
   'shift-enter': 'terminal-status:toggle'
   'alt-shift-t': 'terminal-status:new'
   'alt-shift-j': 'terminal-status:next'
   'alt-shift-k': 'terminal-status:prev'
+  'alt-shift-x': 'terminal-status:destroy'

--- a/keymaps/cli-status.cson
+++ b/keymaps/cli-status.cson
@@ -7,8 +7,14 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'.platform-darwin .workspace':
   'shift-enter': 'terminal-status:toggle'
   'cmd-shift-t': 'terminal-status:new'
   'cmd-shift-j': 'terminal-status:next'
   'cmd-shift-k': 'terminal-status:prev'
+
+'.platform-linux .workspace, .platform-win32 .workspace':
+  'shift-enter': 'terminal-status:toggle'
+  'alt-shift-t': 'terminal-status:new'
+  'alt-shift-j': 'terminal-status:next'
+  'alt-shift-k': 'terminal-status:prev'

--- a/keymaps/cli-status.cson
+++ b/keymaps/cli-status.cson
@@ -20,3 +20,7 @@
   'alt-shift-j': 'terminal-status:next'
   'alt-shift-k': 'terminal-status:prev'
   'alt-shift-x': 'terminal-status:destroy'
+
+'.cli-status':
+  'cmd-c': 'native!'
+  'ctrl-c': 'native!'

--- a/lib/cli-status-view.coffee
+++ b/lib/cli-status-view.coffee
@@ -67,4 +67,5 @@ class CliStatusView extends View
     @detach()
 
   toggle: ->
-    @commandViews[@activeIndex] and @commandViews[@activeIndex].toggle()
+    @createCommandView() unless @commandViews[@activeIndex]?
+    @commandViews[@activeIndex].toggle()

--- a/lib/cli-status-view.coffee
+++ b/lib/cli-status-view.coffee
@@ -16,6 +16,7 @@ class CliStatusView extends View
     atom.workspaceView.command 'terminal-status:toggle', => @toggle()
     atom.workspaceView.command 'terminal-status:next', => @activeNextCommandView()
     atom.workspaceView.command 'terminal-status:prev', => @activePrevCommandView()
+    atom.workspaceView.command 'terminal-status:destroy', => @destroyActiveTerm()
     @createCommandView()
     @attach()
 
@@ -55,8 +56,9 @@ class CliStatusView extends View
 
   attach: ->
     atom.workspaceView.statusBar.appendLeft(this)
-  # Returns an object that can be retrieved when package is activated
-  # serialize: ->
+
+  destroyActiveTerm: ->
+     @commandViews[@activeIndex]?.destroy()
 
   # Tear down any state and detach
   destroy: ->

--- a/lib/cli-status-view.coffee
+++ b/lib/cli-status-view.coffee
@@ -7,7 +7,7 @@ class CliStatusView extends View
   @content: ->
     @div class: 'cli-status inline-block', =>
       @span outlet: 'termStatusContainer', =>
-      @span click: 'newTermClick', class: "cli-status icon icon-plus"
+        @span click: 'newTermClick', class: "cli-status icon icon-plus"
 
   commandViews: []
   activeIndex: 0
@@ -20,21 +20,21 @@ class CliStatusView extends View
     @createCommandView()
     @attach()
 
-  createCommandView: ()->
+  createCommandView: ->
     termStatus = domify '<span class="cli-status icon icon-terminal"></span>'
     commandOutputView = new CommandOutputView
     commandOutputView.statusIcon = termStatus
     commandOutputView.statusView = this
     @commandViews.push commandOutputView
-    termStatus.addEventListener 'click', () =>
+    termStatus.addEventListener 'click', ->
       commandOutputView.toggle()
     @termStatusContainer.append termStatus
     return commandOutputView
 
-  activeNextCommandView: ()->
+  activeNextCommandView: ->
     @activeCommandView @activeIndex + 1
 
-  activePrevCommandView: ()->
+  activePrevCommandView: ->
     @activeCommandView @activeIndex - 1
 
   activeCommandView: (index) ->
@@ -51,7 +51,7 @@ class CliStatusView extends View
     index = @commandViews.indexOf commandView
     index >=0 and @commandViews.splice index, 1
 
-  newTermClick: ()->
+  newTermClick: ->
     @createCommandView().toggle()
 
   attach: ->

--- a/lib/cli-status.coffee
+++ b/lib/cli-status.coffee
@@ -21,3 +21,4 @@ module.exports =
 
   configDefaults:
     'WindowHeight': 300
+    'clearCommandInput': true

--- a/lib/cli-status.coffee
+++ b/lib/cli-status.coffee
@@ -22,3 +22,4 @@ module.exports =
   configDefaults:
     'WindowHeight': 300
     'clearCommandInput': true
+    'logConsole': false

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -67,6 +67,7 @@ class CommandOutputView extends View
   showCmd: ->
     @cmdEditor.show()
     @cmdEditor.getEditor().selectAll()
+    @cmdEditor.setText('') if atom.config.get('terminal-status.clearCommandInput')
     @cmdEditor.focus()
     @scrollToBottom()
 

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -54,8 +54,11 @@ class CommandOutputView extends View
         return @cd args
       if cmd == 'ls'
         return @ls args
+      if cmd == 'clear'
+        @cliOutput.empty()
+        @message '\n'
+        return @cmdEditor.setText ''
       @spawn inputCmd, cmd, args
-
 
   adjustWindowHeight: ->
     maxHeight = atom.config.get('terminal-status.WindowHeight')

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -32,7 +32,7 @@ class CommandOutputView extends View
   initialize: ->
     @subscribe atom.config.observe 'terminal-status.WindowHeight', => @adjustWindowHeight()
 
-    @userHome = process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE;
+    @userHome = process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE
     cmd = 'test -e /etc/profile && source /etc/profile;test -e ~/.profile && source ~/.profile; node -pe "JSON.stringify(process.env)"'
     exec cmd, (code, stdout, stderr) ->
       process.env = JSON.parse(stdout)
@@ -116,7 +116,7 @@ class CommandOutputView extends View
     else
       @open()
 
-  cd: (args)->
+  cd: (args) ->
     dir = resolve @getCwd(), args[0]
     fs.stat dir, (err, stat) =>
       if err
@@ -128,12 +128,12 @@ class CommandOutputView extends View
       @cwd = dir
       @message "cwd: #{@cwd}"
 
-  ls: (args)->
+  ls: (args) ->
     files = fs.readdirSync @getCwd()
     filesBlocks = []
     files.forEach (filename) =>
       filesBlocks.push @_fileInfoHtml(filename, @getCwd())
-    filesBlocks = filesBlocks.sort (a, b)->
+    filesBlocks = filesBlocks.sort (a, b) ->
       aDir = a[1].isDirectory()
       bDir = b[1].isDirectory()
       if aDir and not bDir
@@ -145,7 +145,7 @@ class CommandOutputView extends View
       b[0]
     @message filesBlocks.join('') + '<div class="clear"/>'
 
-  _fileInfoHtml: (filename, parent)->
+  _fileInfoHtml: (filename, parent) ->
     classes = ['icon', 'file-info']
     filepath = parent + '/' + filename
     stat = fs.lstatSync filepath
@@ -196,7 +196,7 @@ class CommandOutputView extends View
     removeClass @statusIcon, 'status-success'
     addClass @statusIcon, 'status-error'
 
-  getCwd: ()->
+  getCwd: ->
     @cwd or atom.project.path or @userHome
 
   spawn: (inputCmd, cmd, args) ->
@@ -227,10 +227,10 @@ class CommandOutputView extends View
         @cliOutput.append err.message
         @showCmd()
         addClass @statusIcon, 'status-error'
-      @program.stdout.on 'data', () =>
+      @program.stdout.on 'data', =>
         @flashIconClass 'status-info'
         removeClass @statusIcon, 'status-error'
-      @program.stderr.on 'data', () =>
+      @program.stderr.on 'data', =>
         console.log 'stderr'
         @flashIconClass 'status-error', 300
 

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -178,7 +178,6 @@ class CommandOutputView extends View
 
   getGitStatusName: (path, gitRoot, repo) ->
     status = (repo.getCachedPathStatus or repo.getPathStatus)(path)
-    console.log 'path status', path, status
     if status
       if repo.isStatusModified status
         return 'modified'
@@ -218,7 +217,7 @@ class CommandOutputView extends View
       addClass @statusIcon, 'status-running'
       @killBtn.removeClass 'hide'
       @program.once 'exit', (code) =>
-        console.log 'exit', code
+        console.log 'exit', code if atom.config.get('terminal-status.logConsole')
         @killBtn.addClass 'hide'
         removeClass @statusIcon, 'status-running'
         # removeClass @statusIcon, 'status-error'
@@ -226,7 +225,7 @@ class CommandOutputView extends View
         addClass @statusIcon, code == 0 and 'status-success' or 'status-error'
         @showCmd()
       @program.on 'error', (err) =>
-        console.log 'error'
+        console.log 'error' if atom.config.get('terminal-status.logConsole')
         @cliOutput.append err.message
         @showCmd()
         addClass @statusIcon, 'status-error'
@@ -234,7 +233,7 @@ class CommandOutputView extends View
         @flashIconClass 'status-info'
         removeClass @statusIcon, 'status-error'
       @program.stderr.on 'data', =>
-        console.log 'stderr'
+        console.log 'stderr' if atom.config.get('terminal-status.logConsole')
         @flashIconClass 'status-error', 300
 
     catch err

--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -71,7 +71,6 @@ class CommandOutputView extends View
     @cliOutput.scrollTop 10000000
 
   flashIconClass: (className, time=100)=>
-    console.log 'addClass', className
     addClass @statusIcon, className
     @timer and clearTimeout(@timer)
     onStatusOut = =>


### PR DESCRIPTION
1. **You can now copy from the terminal output!** :dancer: 
2. Add keybindings for Linux and Windows (`Alt` instead of `Cmd`).
3. Add keybinding to destroy active term (`Cmd-Shift-x` / `Alt-Shift-x`).
4. Toggle keybinding now works if we have no active terms (destroyed all old ones).
5. Some code cleanup, coffeelint compliant.
6. `Clear Command Input` in settings allows the user to automatically remove the command from the editor after being executed. (Default: **true**)
7. `Log Console` in settings allows the user to toggle the debugging to atom console. (Default: **false**)
