### PR TITLE
Bugfix: Uncaught exception occurs when 'cd' takes none args. 

### DIFF
--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -117,6 +117,7 @@ class CommandOutputView extends View
       @open()
 
   cd: (args)->
+    args = [atom.project.path] if not args[0]
     dir = resolve @getCwd(), args[0]
     fs.stat dir, (err, stat) =>
       if err


### PR DESCRIPTION
Use the root of the Project as default
