### PR TITLE
fix uncaught exception for trying to get profile variables

### DIFF
--- a/lib/command-output-view.coffee
+++ b/lib/command-output-view.coffee
@@ -35,7 +35,9 @@ class CommandOutputView extends View
     @userHome = process.env.HOME or process.env.HOMEPATH or process.env.USERPROFILE;
     cmd = 'test -e /etc/profile && source /etc/profile;test -e ~/.profile && source ~/.profile; node -pe "JSON.stringify(process.env)"'
     exec cmd, (code, stdout, stderr) ->
-      process.env = JSON.parse(stdout)
+      try
+        process.env = JSON.parse(stdout)
+      catch e
     atom.workspaceView.command "cli-status:toggle-output", =>
       @toggle()
 


### PR DESCRIPTION
Simply wraps JSON.parse in try/catch

Should fix #24 #20 #17 
