### PR TITLE
Toggle creates new

### DIFF
--- a/lib/cli-status-view.coffee
+++ b/lib/cli-status-view.coffee
@@ -72,4 +72,8 @@ class CliStatusView extends View
     @commandSubscription.dispose()
 
   toggle: ->
-    @commandViews[@activeIndex] and @commandViews[@activeIndex].toggle()
+    if @commandViews[@activeIndex]
+      @commandViews[@activeIndex].toggle()
+    else
+      @newTermClick()
+    


### PR DESCRIPTION
When toggle is activated, a new terminal will be created if one doesn't exist. This is a very handy way to activate a new terminal.